### PR TITLE
Multi language support: Spanish locale config

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -17,10 +17,10 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="12f788ab-0aea-4cd4-aef2-ea7f8311b508" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/ProxiPalTest_client_20231205232005/app/src/main/res/xml/locales_config.xml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/ProxiPalTest_client_20231205232005/app/src/main/res/values-es/strings.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/ProxiPalTest_client_20231205232005/app/build.gradle.kts" beforeDir="false" afterPath="$PROJECT_DIR$/ProxiPalTest_client_20231205232005/app/build.gradle.kts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/ProxiPalTest_client_20231205232005/app/src/main/AndroidManifest.xml" beforeDir="false" afterPath="$PROJECT_DIR$/ProxiPalTest_client_20231205232005/app/src/main/AndroidManifest.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/ProxiPalTest_client_20231205232005/app/src/main/res/values/atlasConfig.xml" beforeDir="false" afterPath="$PROJECT_DIR$/ProxiPalTest_client_20231205232005/app/src/main/res/values/atlasConfig.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/ProxiPalTest_client_20231205232005/app/src/main/res/values/strings.xml" beforeDir="false" afterPath="$PROJECT_DIR$/ProxiPalTest_client_20231205232005/app/src/main/res/values/strings.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -78,6 +78,7 @@
     <option name="RECENT_TEMPLATES">
       <list>
         <option value="resourceFile" />
+        <option value="valueResourceFile" />
       </list>
     </option>
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -17,9 +17,9 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="12f788ab-0aea-4cd4-aef2-ea7f8311b508" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/ProxiPalTest_client_20231205232005/app/src/main/res/values-es/strings.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/ProxiPalTest_client_20231205232005/app/src/main/res/values/atlasConfig.xml" beforeDir="false" afterPath="$PROJECT_DIR$/ProxiPalTest_client_20231205232005/app/src/main/res/values/atlasConfig.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/ProxiPalTest_client_20231205232005/app/src/main/java/com/mongodb/app/TemplateApp.kt" beforeDir="false" afterPath="$PROJECT_DIR$/ProxiPalTest_client_20231205232005/app/src/main/java/com/mongodb/app/TemplateApp.kt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/ProxiPalTest_client_20231205232005/app/src/main/res/values-es/strings.xml" beforeDir="false" afterPath="$PROJECT_DIR$/ProxiPalTest_client_20231205232005/app/src/main/res/values-es/strings.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/ProxiPalTest_client_20231205232005/app/src/main/res/values/strings.xml" beforeDir="false" afterPath="$PROJECT_DIR$/ProxiPalTest_client_20231205232005/app/src/main/res/values/strings.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -100,7 +100,7 @@
     "RunOnceActivity.cidr.known.project.marker": "true",
     "cf.first.check.clang-format": "false",
     "cidr.known.project.marker": "true",
-    "git-widget-placeholder": "main",
+    "git-widget-placeholder": "Multi-Language-Support",
     "last_opened_file_path": "C:/Users/brian/OneDrive/Desktop/ProxiPal",
     "settings.editor.selected.configurable": "reference.settingsdialog.project.gradle"
   }

--- a/ProxiPalTest_client_20231205232005/app/src/main/java/com/mongodb/app/TemplateApp.kt
+++ b/ProxiPalTest_client_20231205232005/app/src/main/java/com/mongodb/app/TemplateApp.kt
@@ -5,6 +5,8 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
 import android.util.Log
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.os.LocaleListCompat
 import io.realm.kotlin.mongodb.App
 import io.realm.kotlin.mongodb.AppConfiguration
 
@@ -21,6 +23,9 @@ class TemplateApp: Application() {
 
     override fun onCreate() {
         super.onCreate()
+
+
+
         createNotificationChannel() // Create notification channel for push notifications
         app = App.create(
             AppConfiguration.Builder(getString(R.string.realm_app_id))

--- a/ProxiPalTest_client_20231205232005/app/src/main/res/values-es/strings.xml
+++ b/ProxiPalTest_client_20231205232005/app/src/main/res/values-es/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">ProxiPal</string>
+    <string name="prompt_email">Correo electrónico</string>
+    <string name="prompt_password">Contraseña</string>
+    <string name="create_account">Crear una cuenta</string>
+    <string name="log_in">Acceso</string>
+    <string name="already_have_account">¿Ya tienes una cuenta? Acceso</string>
+    <string name="does_not_have_account">¿No tienes una cuenta? Crear una cuenta</string>
+    <string name="log_out">Cerrar sesión</string>
+    <string name="airplane_mode">Modo avión</string>
+    <string name="show_completed_tasks_only">Mostrar sólo las tareas completadas</string>
+    <string name="mine">Mío</string>
+    <string name="new_friend_request_notification_service_content_body">¡Tienes una nueva solicitud de amistad!</string>
+</resources>

--- a/ProxiPalTest_client_20231205232005/app/src/main/res/values-es/strings.xml
+++ b/ProxiPalTest_client_20231205232005/app/src/main/res/values-es/strings.xml
@@ -11,5 +11,26 @@
     <string name="airplane_mode">Modo avión</string>
     <string name="show_completed_tasks_only">Mostrar sólo las tareas completadas</string>
     <string name="mine">Mío</string>
+    <string name="delete">Borrar</string>
+    <string name="add_item">Añadir artículo</string>
+    <string name="enter_item_name">Ingrese el nombre del artículo:</string>
+    <string name="cancel">Cancelar</string>
+    <string name="create">Crear</string>
+    <string name="item_summary">Resumen del artículo</string>
+    <string name="permissions_error">No se le permite eliminar o modificar tareas que no le pertenecen.</string>
+    <string name="show_all_tasks">Mostrar todas las tareas</string>
+    <string name="sync_message">Inicie sesión con la misma cuenta en otro dispositivo o simulador para ver su lista sincronizada en tiempo real.</string>
+    <string name="account_clarification">Inicie sesión o regístrese con una cuenta de usuario de Device Sync. Esto es independiente de su inicio de sesión en Atlas Cloud.</string>
+    <string name="unable_to_switch">Cambiar de suscripción no afecta los datos de Realm cuando Sync está fuera de línea</string>
+    <string name="permissions_warning">Sólo puedes modificar o eliminar tareas que te pertenecen.</string>
+    <string name="user_profile_header">Perfil del usuario</string>
+    <string name="user_profile_first_name_header">Nombre</string>
+    <string name="user_profile_last_name_header">Apellido</string>
+    <string name="user_profile_biography_header">Biografía</string>
+    <string name="user_profile_characters_remaining">%s caracteres restantes</string>
+    <string name="user_profile_start_editing_message">Editar perfil</string>
+    <string name="user_profile_finish_editing_message">Guardar cambios</string>
+    <string name="user_profile_cancel_editing_message">Descartar los cambios</string>
+    <string name="user_profile_permissions_warning">Sólo puedes modificar o eliminar un perfil de usuario que te pertenezca.</string>
     <string name="new_friend_request_notification_service_content_body">¡Tienes una nueva solicitud de amistad!</string>
 </resources>

--- a/ProxiPalTest_client_20231205232005/app/src/main/res/values/atlasConfig.xml
+++ b/ProxiPalTest_client_20231205232005/app/src/main/res/values/atlasConfig.xml
@@ -1,9 +1,9 @@
 <resources>
-    <string name="realm_app_id">proxipaltest-jyqla</string>
-    <string name="realm_app_url">https://realm.mongodb.com/groups/656fa44addc7840fec457ec3/apps/656fb0156d484b55836d118e</string>
-    <string name="realm_base_url">https://realm.mongodb.com</string>
-    <string name="realm_client_api_base_url">https://us-east-1.aws.realm.mongodb.com</string>
-    <string name="realm_data_api_base_url">https://us-east-1.aws.data.mongodb-api.com</string>
-    <string name="realm_data_explorer_link">https://cloud.mongodb.com/links/656fa44addc7840fec457ec3/explorer/Cluster0/database/collection/find</string>
-    <string name="realm_data_source_name">mongodb-atlas</string>
+    <string name="realm_app_id" translatable="false">proxipaltest-jyqla</string>
+    <string name="realm_app_url" translatable="false">https://realm.mongodb.com/groups/656fa44addc7840fec457ec3/apps/656fb0156d484b55836d118e</string>
+    <string name="realm_base_url" translatable="false">https://realm.mongodb.com</string>
+    <string name="realm_client_api_base_url" translatable="false">https://us-east-1.aws.realm.mongodb.com</string>
+    <string name="realm_data_api_base_url" translatable="false">https://us-east-1.aws.data.mongodb-api.com</string>
+    <string name="realm_data_explorer_link" translatable="false">https://cloud.mongodb.com/links/656fa44addc7840fec457ec3/explorer/Cluster0/database/collection/find</string>
+    <string name="realm_data_source_name" translatable="false">mongodb-atlas</string>
 </resources>

--- a/ProxiPalTest_client_20231205232005/app/src/main/res/values/strings.xml
+++ b/ProxiPalTest_client_20231205232005/app/src/main/res/values/strings.xml
@@ -12,31 +12,31 @@
     <string name="show_completed_tasks_only">Show completed tasks only</string>
     <string name="mine">Mine</string>
     <string name="more" translatable="false">\u22EE</string>
-    <string name="delete" translatable="false">Delete</string>
-    <string name="add_item" translatable="false">Add Item</string>
-    <string name="enter_item_name" translatable="false">Enter Item Name:</string>
-    <string name="cancel" translatable="false">Cancel</string>
-    <string name="create" translatable="false">Create</string>
-    <string name="item_summary" translatable="false">Item Summary</string>
-    <string name="permissions_error" translatable="false">You are not allowed to delete or modify tasks that don\'t belong to you.</string>
-    <string name="show_all_tasks" translatable="false">Show all tasks</string>
-    <string name="sync_message" translatable="false">Log in with the same account on another device or simulator to see your list sync in real-time.</string>
-    <string name="account_clarification" translatable="false">Please log in or register with a Device Sync user account. This is separate from your Atlas Cloud login.</string>
-    <string name="unable_to_switch" translatable="false">Switching subscriptions does not affect Realm data when Sync is offline</string>
-    <string name="permissions_warning" translatable="false">You can only modify or remove tasks that belong to you.</string>
+    <string name="delete">Delete</string>
+    <string name="add_item">Add Item</string>
+    <string name="enter_item_name">Enter Item Name:</string>
+    <string name="cancel">Cancel</string>
+    <string name="create">Create</string>
+    <string name="item_summary">Item Summary</string>
+    <string name="permissions_error">You are not allowed to delete or modify tasks that don\'t belong to you.</string>
+    <string name="show_all_tasks">Show all tasks</string>
+    <string name="sync_message">Log in with the same account on another device or simulator to see your list sync in real-time.</string>
+    <string name="account_clarification">Please log in or register with a Device Sync user account. This is separate from your Atlas Cloud login.</string>
+    <string name="unable_to_switch">Switching subscriptions does not affect Realm data when Sync is offline</string>
+    <string name="permissions_warning">You can only modify or remove tasks that belong to you.</string>
     <!-- Start user profile strings -->
     <string name="user_profile_test_string" translatable="false">abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789</string>
     <string name="user_profile_empty_string_replacement" translatable="false">(null)</string>
-    <string name="user_profile_header" translatable="false">User Profile</string>
+    <string name="user_profile_header">User Profile</string>
     <string name="user_profile_row_header" translatable="false">%s:</string>
-    <string name="user_profile_first_name_header" translatable="false">First name</string>
-    <string name="user_profile_last_name_header" translatable="false">Last name</string>
-    <string name="user_profile_biography_header" translatable="false">Biography</string>
-    <string name="user_profile_characters_remaining" translatable="false">%s character(s) remaining</string>
-    <string name="user_profile_start_editing_message" translatable="false">Edit Profile</string>
-    <string name="user_profile_finish_editing_message" translatable="false">Save Changes</string>
-    <string name="user_profile_cancel_editing_message" translatable="false">Discard Changes</string>
-    <string name="user_profile_permissions_warning" translatable="false">You can only modify or remove a user profile that belongs to you.</string>
+    <string name="user_profile_first_name_header">First name</string>
+    <string name="user_profile_last_name_header">Last name</string>
+    <string name="user_profile_biography_header">Biography</string>
+    <string name="user_profile_characters_remaining">%s character(s) remaining</string>
+    <string name="user_profile_start_editing_message">Edit Profile</string>
+    <string name="user_profile_finish_editing_message">Save Changes</string>
+    <string name="user_profile_cancel_editing_message">Discard Changes</string>
+    <string name="user_profile_permissions_warning">You can only modify or remove a user profile that belongs to you.</string>
     <!-- End user profile strings-->
 
 

--- a/ProxiPalTest_client_20231205232005/app/src/main/res/values/strings.xml
+++ b/ProxiPalTest_client_20231205232005/app/src/main/res/values/strings.xml
@@ -11,36 +11,37 @@
     <string name="airplane_mode">Airplane Mode</string>
     <string name="show_completed_tasks_only">Show completed tasks only</string>
     <string name="mine">Mine</string>
-    <string name="more">\u22EE</string>
-    <string name="delete">Delete</string>
-    <string name="add_item">Add Item</string>
-    <string name="enter_item_name">Enter Item Name:</string>
-    <string name="cancel">Cancel</string>
-    <string name="create">Create</string>
-    <string name="item_summary">Item Summary</string>
-    <string name="permissions_error">You are not allowed to delete or modify tasks that don\'t belong to you.</string>
-    <string name="show_all_tasks">Show all tasks</string>
-    <string name="sync_message">Log in with the same account on another device or simulator to see your list sync in real-time.</string>
-    <string name="account_clarification">Please log in or register with a Device Sync user account. This is separate from your Atlas Cloud login.</string>
-    <string name="unable_to_switch">Switching subscriptions does not affect Realm data when Sync is offline</string>
-    <string name="permissions_warning">You can only modify or remove tasks that belong to you.</string>
+    <string name="more" translatable="false">\u22EE</string>
+    <string name="delete" translatable="false">Delete</string>
+    <string name="add_item" translatable="false">Add Item</string>
+    <string name="enter_item_name" translatable="false">Enter Item Name:</string>
+    <string name="cancel" translatable="false">Cancel</string>
+    <string name="create" translatable="false">Create</string>
+    <string name="item_summary" translatable="false">Item Summary</string>
+    <string name="permissions_error" translatable="false">You are not allowed to delete or modify tasks that don\'t belong to you.</string>
+    <string name="show_all_tasks" translatable="false">Show all tasks</string>
+    <string name="sync_message" translatable="false">Log in with the same account on another device or simulator to see your list sync in real-time.</string>
+    <string name="account_clarification" translatable="false">Please log in or register with a Device Sync user account. This is separate from your Atlas Cloud login.</string>
+    <string name="unable_to_switch" translatable="false">Switching subscriptions does not affect Realm data when Sync is offline</string>
+    <string name="permissions_warning" translatable="false">You can only modify or remove tasks that belong to you.</string>
     <!-- Start user profile strings -->
-    <string name="user_profile_test_string">abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789</string>
-    <string name="user_profile_empty_string_replacement">(null)</string>
-    <string name="user_profile_header">User Profile</string>
-    <string name="user_profile_row_header">%s:</string>
-    <string name="user_profile_first_name_header">First name</string>
-    <string name="user_profile_last_name_header">Last name</string>
-    <string name="user_profile_biography_header">Biography</string>
-    <string name="user_profile_characters_remaining">%s character(s) remaining</string>
-    <string name="user_profile_start_editing_message">Edit Profile</string>
-    <string name="user_profile_finish_editing_message">Save Changes</string>
-    <string name="user_profile_cancel_editing_message">Discard Changes</string>
-    <string name="user_profile_permissions_warning">You can only modify or remove a user profile that belongs to you.</string>
+    <string name="user_profile_test_string" translatable="false">abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789</string>
+    <string name="user_profile_empty_string_replacement" translatable="false">(null)</string>
+    <string name="user_profile_header" translatable="false">User Profile</string>
+    <string name="user_profile_row_header" translatable="false">%s:</string>
+    <string name="user_profile_first_name_header" translatable="false">First name</string>
+    <string name="user_profile_last_name_header" translatable="false">Last name</string>
+    <string name="user_profile_biography_header" translatable="false">Biography</string>
+    <string name="user_profile_characters_remaining" translatable="false">%s character(s) remaining</string>
+    <string name="user_profile_start_editing_message" translatable="false">Edit Profile</string>
+    <string name="user_profile_finish_editing_message" translatable="false">Save Changes</string>
+    <string name="user_profile_cancel_editing_message" translatable="false">Discard Changes</string>
+    <string name="user_profile_permissions_warning" translatable="false">You can only modify or remove a user profile that belongs to you.</string>
     <!-- End user profile strings-->
 
 
     <!-- NewFriendRequestNotificationService strings
          Programmer:Brian Poon 2/21/24   -->
     <string name="new_friend_request_notification_service_content_body">You have a new friend request!</string>
+
 </resources>


### PR DESCRIPTION
Added Spanish local app translation support. Change to Spanish by going to App Languages of ProxiPal and selecting Spanish.